### PR TITLE
Restore importmap audit tooling and align admin routes

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,0 +1,1 @@
+// Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails

--- a/bin/importmap
+++ b/bin/importmap
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+APP_ROOT = File.expand_path('..', __dir__)
+Dir.chdir(APP_ROOT) do
+  exec Gem.bin_path('importmap', 'importmap')
+end

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,0 +1,2 @@
+# Pin npm packages by running ./bin/importmap
+pin "application"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,7 @@ Rails.application.routes.draw do
   resources :categories, except: %i[show]
 
   namespace :admin do
-    resources :users do
+    resources :users, only: %i[index edit update destroy] do
       member do
         patch :promote
         patch :demote


### PR DESCRIPTION
## Summary
- add the standard importmap wrapper and configuration so the audit command can run in CI
- create a placeholder JavaScript entry point expected by importmap tooling
- limit the admin user routes to the actions implemented by Admin::UsersController

## Testing
- bin/rails routes -g admin_users *(fails: missing gems locally)*

------
https://chatgpt.com/codex/tasks/task_e_68f6a9197144832a95c003c53e673933