### PR TITLE
Add inline documentation for controllers and models

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,16 +1,23 @@
 module Admin
   class UsersController < ApplicationController
+    # Every action in the admin namespace requires an authenticated, active
+    # administrator account. The user lookup is reused across the management
+    # operations in this controller.
     before_action :require_login
     before_action :require_active_user
     before_action :require_admin
     before_action :set_user, only: %i[edit update destroy promote demote set_status]
 
+    # Lists the managed users, excluding the current admin to avoid presenting
+    # destructive options that immediately fail.
     def index
       @users = User.where.not(id: current_user.id).order(:first_name, :last_name)
     end
 
+    # Presents the account editing form for administrators.
     def edit; end
 
+    # Saves attribute changes and reports validation issues inline.
     def update
       if @user.update(user_params)
         redirect_to admin_users_path, notice: "User updated successfully."
@@ -19,6 +26,8 @@ module Admin
       end
     end
 
+    # Deletes a user account, guarding against self-deletion so the admin
+    # remains able to manage the system.
     def destroy
       if @user == current_user
         redirect_to admin_users_path, alert: "You cannot delete your own account."
@@ -28,6 +37,7 @@ module Admin
       end
     end
 
+    # Upgrades another account to the admin role.
     def promote
       return redirect_to admin_users_path, alert: "You cannot change your own role." if @user == current_user
 
@@ -35,6 +45,7 @@ module Admin
       redirect_to admin_users_path, notice: "User promoted to admin."
     end
 
+    # Downgrades an admin back to the standard role.
     def demote
       return redirect_to admin_users_path, alert: "You cannot change your own role." if @user == current_user
 
@@ -42,6 +53,8 @@ module Admin
       redirect_to admin_users_path, notice: "User demoted to standard."
     end
 
+    # Applies the requested status transition (active/suspended/banned) after
+    # verifying it is supported and not targeting the acting admin.
     def set_status
       status = params[:status]
       return redirect_to admin_users_path, alert: "You cannot change your own status." if @user == current_user
@@ -56,10 +69,12 @@ module Admin
 
     private
 
+    # Fetches the account targeted by the administrative action.
     def set_user
       @user = User.find(params[:id])
     end
 
+    # Limits admin edits to safe, profile-level attributes.
     def user_params
       params.require(:user).permit(:first_name, :last_name, :email)
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,35 +1,48 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  # Ensure the UI only renders for browsers with the capabilities relied on by
+  # the asset pipeline and interactive components.
   allow_browser versions: :modern
 
+  # Make the authentication helpers available to views so navigation can adapt
+  # to the current visitor’s permissions.
   helper_method :current_user, :logged_in?, :admin?
 
   private
 
+  # Returns the currently logged in user, caching the lookup for the duration
+  # of the request so repeated calls are inexpensive.
   def current_user
     @current_user ||= User.find_by(id: session[:user_id]) if session[:user_id]
   end
 
+  # Convenience predicate used by controllers and views to guard protected
+  # actions or tailor copy to authenticated visitors.
   def logged_in?
     current_user.present?
   end
 
+  # Helper that centralizes the “is admin” check used throughout controllers.
   def admin?
     logged_in? && current_user.admin?
   end
 
+  # Redirect anonymous visitors to the login screen when they try to access an
+  # authenticated workflow.
   def require_login
     return if logged_in?
 
     redirect_to login_path, alert: "You must be logged in to access this page."
   end
 
+  # Guard endpoints that only administrators should reach.
   def require_admin
     return if admin?
 
     redirect_to root_path, alert: "You are not authorized to perform this action."
   end
 
+  # Prevent suspended or banned accounts from continuing a session and explain
+  # why they must contact staff.
   def require_active_user
     return if current_user&.active?
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,19 +1,25 @@
 class CategoriesController < ApplicationController
+  # Only administrators manage categories. The index is public so visitors can
+  # browse available tags without logging in.
   before_action :require_login, except: %i[index]
   before_action :require_active_user, except: %i[index]
   before_action :require_admin, except: %i[index]
   before_action :set_category, only: %i[show edit update destroy]
 
+  # Lists all categories alphabetically for discovery.
   def index
     @categories = Category.order(:name)
   end
 
+  # Displays the details for a single category.
   def show; end
 
+  # Presents a blank form for creating a new category.
   def new
     @category = Category.new
   end
 
+  # Persists a category and redisplays the form when validations fail.
   def create
     @category = Category.new(category_params)
 
@@ -24,8 +30,10 @@ class CategoriesController < ApplicationController
     end
   end
 
+  # Presents the edit form with the existing category data.
   def edit; end
 
+  # Applies updates and keeps the admin on the form if validation errors occur.
   def update
     if @category.update(category_params)
       redirect_to categories_path, notice: "Category updated successfully."
@@ -34,6 +42,7 @@ class CategoriesController < ApplicationController
     end
   end
 
+  # Removes the category and returns to the listing screen.
   def destroy
     @category.destroy
     redirect_to categories_path, notice: "Category removed successfully."
@@ -41,10 +50,12 @@ class CategoriesController < ApplicationController
 
   private
 
+  # Loads the requested category for actions that operate on an existing record.
   def set_category
     @category = Category.find(params[:id])
   end
 
+  # Limits mutations to the single attribute the UI collects.
   def category_params
     params.require(:category).permit(:name)
   end

--- a/app/controllers/philosophers_controller.rb
+++ b/app/controllers/philosophers_controller.rb
@@ -1,19 +1,25 @@
 class PhilosophersController < ApplicationController
+  # Administrators maintain the philosopher catalogue used for quote
+  # attribution. All actions require an active admin session.
   before_action :require_login
   before_action :require_active_user
   before_action :require_admin
   before_action :set_philosopher, only: %i[show edit update destroy]
 
+  # Lists all philosophers alphabetically by their names.
   def index
     @philosophers = Philosopher.order(:first_name, :last_name)
   end
 
+  # Displays the selected philosopher and their associated information.
   def show; end
 
+  # Presents an empty form for recording a new philosopher.
   def new
     @philosopher = Philosopher.new
   end
 
+  # Persists the philosopher record, redisplaying the form when validations fail.
   def create
     @philosopher = Philosopher.new(philosopher_params)
 
@@ -24,8 +30,10 @@ class PhilosophersController < ApplicationController
     end
   end
 
+  # Populates the edit form with the selected philosopher’s details.
   def edit; end
 
+  # Applies updates to the philosopher entry.
   def update
     if @philosopher.update(philosopher_params)
       redirect_to philosophers_path, notice: "Philosopher updated successfully."
@@ -34,6 +42,7 @@ class PhilosophersController < ApplicationController
     end
   end
 
+  # Removes the philosopher, cascading deletes to their quotes.
   def destroy
     @philosopher.destroy
     redirect_to philosophers_path, notice: "Philosopher removed successfully."
@@ -41,10 +50,12 @@ class PhilosophersController < ApplicationController
 
   private
 
+  # Finds the philosopher record targeted by the action.
   def set_philosopher
     @philosopher = Philosopher.find(params[:id])
   end
 
+  # Only allow trusted parameters representing philosopher attributes.
   def philosopher_params
     params.require(:philosopher).permit(:first_name, :last_name, :birth_year, :death_year, :biography)
   end

--- a/app/controllers/public_controller.rb
+++ b/app/controllers/public_controller.rb
@@ -1,4 +1,6 @@
 class PublicController < ApplicationController
+  # Hosts the read-only quote discovery experience for visitors without
+  # requiring authentication.
   def home
     @quotes = Quote.includes(:user, :philosopher, :categories)
                    .where(is_public: true)
@@ -6,6 +8,8 @@ class PublicController < ApplicationController
                    .limit(10)
   end
 
+  # Provides the searchable/filtered quote listing, handling free-text queries
+  # alongside multi-category filters and exposing selected metadata for the UI.
   def quotes
     @query = params[:q].to_s.strip
     @selected_category_ids = Array(params[:categories]).reject(&:blank?).map(&:to_i)
@@ -14,6 +18,8 @@ class PublicController < ApplicationController
                  .where(is_public: true)
 
     if @query.present?
+      # Downcase and wrap the query so we can match against multiple columns in
+      # a case-insensitive fashion while still leveraging SQL LIKE patterns.
       normalized_query = "%#{ActiveRecord::Base.sanitize_sql_like(@query.downcase)}%"
       scope = scope.joins(:philosopher)
                    .left_joins(:categories)
@@ -27,10 +33,14 @@ class PublicController < ApplicationController
                    )
                    .distinct
     else
+      # Even without a free-text search we join philosophers so the view can
+      # render their information without N+1 lookups.
       scope = scope.joins(:philosopher)
     end
 
     if @selected_category_ids.any?
+      # Only include quotes tagged with all selected categories. The HAVING
+      # clause ensures partial matches are excluded.
       matching_ids = Quote.joins(:categories)
                           .where(categories: { id: @selected_category_ids })
                           .group(:id)
@@ -43,6 +53,7 @@ class PublicController < ApplicationController
     @selected_categories = Category.where(id: @selected_category_ids).order(:name)
   end
 
+  # Displays every public quote associated with a specific category.
   def by_category
     @category = Category.find(params[:id])
     @quotes = @category.quotes.includes(:user, :philosopher)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,6 +1,9 @@
 class SessionsController < ApplicationController
+  # Shows the login form.
   def new; end
 
+  # Authenticates the provided credentials, prevents inactive accounts from
+  # logging in, and surfaces precise feedback for failure cases.
   def create
     user = User.find_by(email: params[:email].to_s.strip.downcase)
 
@@ -18,6 +21,7 @@ class SessionsController < ApplicationController
     end
   end
 
+  # Ends the session and returns the visitor to the public homepage.
   def destroy
     reset_session
     redirect_to root_path, notice: "Logged out successfully."

--- a/app/controllers/stylesheets_controller.rb
+++ b/app/controllers/stylesheets_controller.rb
@@ -1,6 +1,9 @@
 class StylesheetsController < ActionController::Base
+  # Serves the legacy compiled stylesheet used by the static marketing pages.
   STYLESHEET_PATH = Rails.root.join("app/assets/stylesheets/application.css").freeze
 
+  # Streams the CSS file directly, caching it for an hour, and logs a helpful
+  # warning if the asset is missing from disk.
   def application
     unless File.file?(STYLESHEET_PATH)
       Rails.logger.warn("Legacy stylesheet requested but #{STYLESHEET_PATH} is missing")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,13 +1,18 @@
 class UsersController < ApplicationController
+  # Registration is open to everyone, but profile edits require the session to
+  # belong to the owner of the account and for the account to be active.
   before_action :require_login, only: %i[edit update]
   before_action :require_active_user, only: %i[edit update]
   before_action :set_user, only: %i[edit update]
   before_action :authorize_user!, only: %i[edit update]
 
+  # Presents the sign-up form for new visitors.
   def new
     @user = User.new
   end
 
+  # Creates a fresh account, defaulting to the standard role and active status,
+  # and logs the user in on success.
   def create
     @user = User.new(user_params)
     @user.role = :standard
@@ -21,8 +26,10 @@ class UsersController < ApplicationController
     end
   end
 
+  # Renders the profile edit form.
   def edit; end
 
+  # Applies profile updates when the data validates successfully.
   def update
     if @user.update(user_params)
       redirect_to root_path, notice: "Profile updated successfully."
@@ -33,16 +40,19 @@ class UsersController < ApplicationController
 
   private
 
+  # Finds the user associated with the form submission.
   def set_user
     @user = User.find(params[:id])
   end
 
+  # Prevents one user from modifying another user’s account.
   def authorize_user!
     return if current_user == @user
 
     redirect_to root_path, alert: "You are not authorized to modify this account."
   end
 
+  # Allows only the fields collected on the profile forms.
   def user_params
     params.require(:user).permit(:first_name, :last_name, :email, :password, :password_confirmation)
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
+  # Shared base class for Active Record models in the application.
   primary_abstract_class
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,6 +1,10 @@
 class Category < ApplicationRecord
+  # Categories label quotes and cascade deletes through the join table so stale
+  # associations are cleaned up automatically.
   has_many :quote_categories, dependent: :destroy
   has_many :quotes, through: :quote_categories
 
+  # Each category needs a unique name so it can be referenced reliably in forms
+  # and filters.
   validates :name, presence: true, uniqueness: true
 end

--- a/app/models/philosopher.rb
+++ b/app/models/philosopher.rb
@@ -1,5 +1,8 @@
 class Philosopher < ApplicationRecord
+  # Philosophers own many quotes; removing one cascades to their quotes to avoid
+  # orphan records.
   has_many :quotes, dependent: :destroy
 
+  # Require a first name so the UI can render a meaningful display name.
   validates :first_name, presence: true
 end

--- a/app/models/quote.rb
+++ b/app/models/quote.rb
@@ -1,15 +1,21 @@
 class Quote < ApplicationRecord
+  # Quotes originate from a user and must point to a philosopher. Categories are
+  # managed via the join table.
   belongs_to :user
   belongs_to :philosopher
   has_many :quote_categories, dependent: :destroy
   has_many :categories, through: :quote_categories
 
+  # Require meaningful quote content and explicit publication state so the UI
+  # knows whether to expose it publicly.
   validates :text, presence: true
   validates :is_public, inclusion: { in: [true, false] }
   validate :must_have_category
 
   private
 
+  # Enforces that every quote is tagged with at least one category, ensuring it
+  # appears in filtered searches.
   def must_have_category
     ids = Array(category_ids).reject(&:blank?)
     errors.add(:categories, "must include at least one") if ids.empty?

--- a/app/models/quote_category.rb
+++ b/app/models/quote_category.rb
@@ -1,6 +1,8 @@
 class QuoteCategory < ApplicationRecord
+  # Join model linking quotes to their categories.
   belongs_to :quote
   belongs_to :category
 
+  # Prevent duplicate category assignments for the same quote.
   validates :quote_id, uniqueness: { scope: :category_id }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,14 +1,23 @@
 class User < ApplicationRecord
+  # Handles password hashing/verification and exposes `authenticate`.
   has_secure_password
 
+  # Roles control access to administrative features; status tracks account
+  # health so suspended users can be locked out without deleting data.
   enum :role, { standard: 0, admin: 1 }
   enum :status, { active: 0, suspended: 1, banned: 2 }
 
+  # Users author many quotes; removing a user clears their contributions to
+  # maintain referential integrity.
   has_many :quotes, dependent: :destroy
 
+  # Core profile details and email uniqueness ensure we can contact the user and
+  # log them in reliably.
   validates :first_name, :last_name, :email, presence: true
   validates :email, uniqueness: true
 
+  # Keep emails normalized so uniqueness comparisons are case-insensitive and
+  # whitespace-safe.
   before_validation :normalize_email
 
   private


### PR DESCRIPTION
## Summary
- add descriptive comments across user, admin, and resource controllers to clarify their responsibilities and filters
- document model associations, validations, and callbacks to explain key integrity rules

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68f6ad64f054832ab968dcc9f28d3244